### PR TITLE
feat: Rename object to HyperMath.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const SuperMath = class {
+const HyperMath = class {
   /* eslint-disable class-methods-use-this */
   subtract (minuend, subtrahend) {
     return minuend - subtrahend;
@@ -8,4 +8,4 @@ const SuperMath = class {
   /* eslint-enable class-methods-use-this */
 };
 
-module.exports = SuperMath;
+module.exports = HyperMath;

--- a/tests/unit/indexTest.js
+++ b/tests/unit/indexTest.js
@@ -2,11 +2,11 @@
 
 const assert = require('assertthat');
 
-const SuperMath = require('../../..lib');
+const HyperMath = require('../../..lib');
 
-suite('SuperMath', () => {
+suite('HyperMath', () => {
   test('is a function.', done => {
-    assert.that(SuperMath).is.ofType('function');
+    assert.that(HyperMath).is.ofType('function');
     done();
   });
 
@@ -14,7 +14,7 @@ suite('SuperMath', () => {
     let myMath;
 
     setup(() => {
-      myMath = new SuperMath();
+      myMath = new HyperMath();
     });
 
     test('is a function.', done => {


### PR DESCRIPTION
SuperMath does not emphasize enough how extraordinary this module is. So, it has been renamed to HyperMath.

BREAKING CHANGE: The name of the constructor must be changed from 'SuperMath' to 'HyperMath'.